### PR TITLE
Fixed a position computation error

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Chase.h
+++ b/src/Kaleidoscope-LEDEffect-Chase.h
@@ -12,7 +12,7 @@ class LEDChaseEffect : public LEDMode {
   void update(void) final;
 
  private:
-  uint8_t pos = 0;
+  uint8_t pos = 5;
   int8_t chase_sign = 1; //negative values when it's going backwar
   uint8_t chase_pixels = 5;
   uint8_t current_chase_counter = 0;


### PR DESCRIPTION
There is an error in the computation of the `pos` value 
```cpp
::LEDControl.setCrgbAt(pos - (chase_sign * chase_pixels), {0, 0, 0});
  ::LEDControl.setCrgbAt(pos, {0, 0, 0});

  pos += chase_sign;
  if (pos >= LED_COUNT || pos <= 0) {
    chase_sign = -chase_sign;
  }
  ::LEDControl.setCrgbAt(pos, {0, 0, 255});
  ::LEDControl.setCrgbAt(pos - (chase_sign * chase_pixels), {255, 0, 0});
```
In the first step, `pos` is `0`, `chase_sign` is `1` and `chase_pixels` is positive `5`. The results of `pos - (chase_sign * chase_pixels)` is thus `251`, which is out of range for the color access. In the same loop cycle, the last access is a position `252` also out of range.
This can be fix by initializing `pos` with the same value as `chase_pixels`.

The plugin seem to work well on the Model01 hardware but it crashes my simulator as it creates a nasty wild pointer.

I would recommend to add assertions to all access of array entries. This will make such errors easily trackable using simulation, e.g. as part of a future regression testing system.