### PR TITLE
Slow down the chase to reflect the recent optimizations

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Chase.h
+++ b/src/Kaleidoscope-LEDEffect-Chase.h
@@ -16,7 +16,7 @@ class LEDChaseEffect : public LEDMode {
   int8_t chase_sign = 1; //negative values when it's going backwar
   uint8_t chase_pixels = 5;
   uint8_t current_chase_counter = 0;
-  static const uint8_t chase_threshold = 20;
+  static const uint8_t chase_threshold = 150;
 };
 }
 


### PR DESCRIPTION
Really, this should probably use a timer, but simply changing the `chase_threshold` value is simpler for now.