### PR TITLE
Change the upper bound to match the lower bound

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Chase.cpp
+++ b/src/Kaleidoscope-LEDEffect-Chase.cpp
@@ -10,7 +10,7 @@ void LEDChaseEffect::update(void) {
   ::LEDControl.setCrgbAt(pos, {0, 0, 0});
 
   pos += chase_sign;
-  if (pos >= LED_COUNT || pos <= 0) {
+  if (pos >= (LED_COUNT - 1) || pos <= 0) {
     chase_sign = -chase_sign;
   }
   ::LEDControl.setCrgbAt(pos, {0, 0, 255});


### PR DESCRIPTION
This causes the red light to stop when in gets to the last key, rather than continuing on past the end of the array before turning around.