### PR TITLE
Fix for all out of bounds LED addressing

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Chase.cpp
+++ b/src/Kaleidoscope-LEDEffect-Chase.cpp
@@ -2,26 +2,42 @@
 
 namespace kaleidoscope {
 void LEDChaseEffect::update(void) {
+  // Check to see if it's time to change the positions of the red and blue lights
   if (current_chase_counter++ < chase_threshold) {
     return;
   }
   current_chase_counter = 0;
 
+  // The red LED is at `pos`; the blue one follows behind. `chase_sign` is either +1 or
+  // -1; `chase_pixels` is the gap between them.
   byte pos2 = pos - (chase_sign * chase_pixels);
 
+  // First, we turn off the LEDs that were turned on in the previous update. `pos` is
+  // always in the valid range (0 <= pos < LED_COUNT), but after it changes direction, for
+  // the first few updates, `pos2` will be out of bounds. Since it's an unsigned integer,
+  // even when it would have a value below zero, it underflows and so one test is good for
+  // both ends of the range.
   ::LEDControl.setCrgbAt(pos, {0, 0, 0});
   if (pos2 < LED_COUNT)
     ::LEDControl.setCrgbAt(pos2, {0, 0, 0});
 
+  // Next, we adjust the red light's position. If the direction hasn't changed (the red
+  // light isn't out of bounds), we also adjust the blue light's position to match the red
+  // one. If the new position puts it out of bounds, we reverse the direction, and bring
+  // it back in bounds. When this happens, the blue light "jumps" behind the red one, and
+  // will be out of bounds. The simplest way to do this is to assign it a value that is
+  // known to be invalid (LED_COUNT).
   pos += chase_sign;
-  if (! (pos < LED_COUNT)) {
+  if (pos < LED_COUNT) {
+    pos2 += chase_sign;
+  } else {
     chase_sign = -chase_sign;
     pos += chase_sign;
     pos2 = LED_COUNT;
-  } else {
-    pos2 += chase_sign;
   }
 
+  // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
+  // only set if it's in the valid LED range.
   ::LEDControl.setCrgbAt(pos, {0, 0, 255});
   if (pos2 < LED_COUNT)
     ::LEDControl.setCrgbAt(pos2, {255, 0, 0});

--- a/src/Kaleidoscope-LEDEffect-Chase.cpp
+++ b/src/Kaleidoscope-LEDEffect-Chase.cpp
@@ -6,15 +6,25 @@ void LEDChaseEffect::update(void) {
     return;
   }
   current_chase_counter = 0;
-  ::LEDControl.setCrgbAt(pos - (chase_sign * chase_pixels), {0, 0, 0});
+
+  byte pos2 = pos - (chase_sign * chase_pixels);
+
   ::LEDControl.setCrgbAt(pos, {0, 0, 0});
+  if (pos2 < LED_COUNT)
+    ::LEDControl.setCrgbAt(pos2, {0, 0, 0});
 
   pos += chase_sign;
-  if (pos >= (LED_COUNT - 1) || pos <= 0) {
+  if (! (pos < LED_COUNT)) {
     chase_sign = -chase_sign;
+    pos += chase_sign;
+    pos2 = LED_COUNT;
+  } else {
+    pos2 += chase_sign;
   }
+
   ::LEDControl.setCrgbAt(pos, {0, 0, 255});
-  ::LEDControl.setCrgbAt(pos - (chase_sign * chase_pixels), {255, 0, 0});
+  if (pos2 < LED_COUNT)
+    ::LEDControl.setCrgbAt(pos2, {255, 0, 0});
 }
 }
 


### PR DESCRIPTION
This is a somewhat unwieldy fix for all the out of bounds (attempted) array addressing at both ends. When `pos` goes out of bounds in either direction, the test is the same because it's an unsigned integer. However, after the change of direction, the trailing LED will still be out of bounds, so we check that every time we call `setCrgbAt()` for `pos2`.

It's rather ugly, but it does ensure that we don't call `setCrgbAt()` with an out-of-bounds address.